### PR TITLE
setup github actions 'Release' and mod 'Build'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,12 @@ name: Build
 
 on:
   push:
+    branches:
+      # build at all branches except "master"
+      - '**' 
+      - '!master' 
+    tags-ignore:
+      - 'v*' # v* trigger release.yml
 jobs:
   build:
     runs-on: windows-latest
@@ -12,8 +18,20 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2 
     - name: Setup VSTest Path
       uses: darenm/Setup-VSTest@v1
-    - run: .\scripts\install_dependencies.ps1
-    - run: MSBuild BuffettCode.sln
-    - run: VSTest.Console.exe .\BuffettCodeTest\bin\Debug\BuffettCodeTest.dll .\BuffettCodeAddinTest\bin\Debug\BuffettCodeAddinTest.dll
+    - name: Install dependencies
+      run: .\scripts\install_dependencies.ps1
+    - name: Run MSBuild as Release mode
+      run: MSBuild BuffettCode.sln /p:Configuration=Release
+    - name: Run VSTest using Test API Token
+      run: .\scripts\run_all_tests.ps1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ap-northeast-1
+    - name: Upload new Installer to s3
       env:
-        BCODE_KEY: sAJGq9JH193KiwnF947v74KnDYkO7z634LWQQfPY
+        S3_BUCKET: ${{ secrets.S3_INSTALLER_BUCKET }}
+        GIT_BRANCH: ${{ github.ref }}
+      run: .\scripts\upload_new_installer.ps1 "$env:S3_BUCKET" "$env:GIT_BRANCH".Replace('refs/heads', 'build/branches')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# ref https://github.com/microsoft/setup-msbuild
+
+name: Release
+
+on:
+  push:
+    branches:
+    - 'master' # to run beta release
+
+    tags:
+      - 'v*' # only v* tag trigger release.yml
+jobs:
+  build_and_release:
+    runs-on: windows-latest
+    env:
+        CODE_SIGNING_CERTIFICATE: 'BuffettCode.pfx'
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2 
+    - name: Setup VSTest Path
+      uses: darenm/Setup-VSTest@v1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ap-northeast-1
+    - name: Setup code signing certificate
+      env:
+        CODE_SIGNING_CERTIFICATE_S3_URI: ${{ secrets.S3_CODE_SIGNING_PFX_URI }}
+        CODE_SIGNING_CERTIFICATE_LOCAL: .\BuffettCode\${{ env.CODE_SIGNING_CERTIFICATE }}
+        CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_PFX_PASS }}
+      run: 
+        .\scripts\setup_code_signing_certificate.ps1 "$env:CODE_SIGNING_CERTIFICATE_S3_URI" "$env:CODE_SIGNING_CERTIFICATE_LOCAL" "$env:CERTIFICATE_PASSWORD"
+    - name: Install dependencies
+      run: .\scripts\install_dependencies.ps1
+    - name: Run MSBuild using code signing certificate
+      run: MSBuild BuffettCode.sln /p:Configuration=Release /p:ManifestKeyFile="$env:CODE_SIGNING_CERTIFICATE" /p:ManifestCertificateThumbprint=${{ secrets.MANIFEST_CERTIFICATE_THUMBPRINT }}
+    - name: Run VSTest using Test API Token
+      run: .\scripts\run_all_tests.ps1
+    - if: ${{ github.ref == 'refs/heads/master' }}
+      name: Beta Release
+      env:
+        S3_BUCKET: ${{ secrets.S3_INSTALLER_BUCKET }}
+      run: .\scripts\upload_new_installer.ps1 "$env:S3_BUCKET" "beta/latest"
+    - if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      name: Release By tags
+      env:
+        S3_BUCKET: ${{ secrets.S3_INSTALLER_BUCKET }}
+        GIT_TAG: ${{ github.ref }}
+      run: .\scripts\upload_new_installer.ps1 "$env:S3_BUCKET" "$env:GIT_TAG".Replace('refs/tags', 'release')

--- a/BuffettCodeAddinTest/BuffettCodeTestUtils.cs
+++ b/BuffettCodeAddinTest/BuffettCodeTestUtils.cs
@@ -13,7 +13,7 @@ namespace BuffettCodeAddin.UnitTests
         /// <returns>APIキー</returns>
         public static string GetValidApiKey()
         {
-            var key = Environment.GetEnvironmentVariable("BCODE_KEY");
+            var key = Environment.GetEnvironmentVariable("BCApiKey");
             if (string.IsNullOrEmpty(key))
             {
                 Configuration.Reload();

--- a/scripts/install_dependencies.ps1
+++ b/scripts/install_dependencies.ps1
@@ -1,5 +1,5 @@
-$packages = ("BuffettCode", "BuffettCodeTest", "BuffettCodeAddin", "BuffettCodeAddinTest", "BuffettCodeInstaller", "InstallerCA")
-foreach($pkg in $packages) {
-    echo "install package in $pkg"
-    nuget install $pkg\packages.config -OutputDirectory packages
+$Packages = ("BuffettCode", "BuffettCodeTest", "BuffettCodeAddin", "BuffettCodeAddinTest", "BuffettCodeInstaller", "InstallerCA")
+foreach($Pkg in $Packages) {
+    echo "install package in $Pkg"
+    nuget install $Pkg\packages.config -OutputDirectory packages
 }

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -1,0 +1,2 @@
+$Env:BCApiKey= "sAJGq9JH193KiwnF947v74KnDYkO7z634LWQQfPY"
+VSTest.Console.exe .\BuffettCodeTest\bin\Release\BuffettCodeTest.dll .\BuffettCodeAddinTest\bin\Release\BuffettCodeAddinTest.dll

--- a/scripts/setup_code_signing_certificate.ps1
+++ b/scripts/setup_code_signing_certificate.ps1
@@ -1,0 +1,5 @@
+Param([string] $S3Uri, $CertificatePath, $Pass)
+echo "Download an code sigining certificate to $CertificatePath from s3"
+aws s3 cp "$S3Uri" "$CertificatePath" --quiet
+echo "Import the certificate::$CertificatePath"
+CertUtil -user -f -p "$Pass" -importpfx "$CertificatePath" NoRoot

--- a/scripts/upload_new_installer.ps1
+++ b/scripts/upload_new_installer.ps1
@@ -1,0 +1,5 @@
+Param([string] $S3Bucket, $SubFolder)
+$LocalInstaller = ".\BuffettCodeInstaller\bin\Release\ja-JP\BuffettCodeInstaller.msi"
+$Folder = "buffett-code-excel-addin/$SubFolder"
+echo "upload an installer: $LocalInstaller to s3"
+aws s3 cp "$LocalInstaller" "s3://$S3Bucket/$Folder/BuffettCodeExcelAddinInstaller.msi" --quiet 


### PR DESCRIPTION
ref: https://github.com/BuffettCode/buffett-code-api-client-excel/issues/2

- [x] build されたinstaller を バフェット・コード の s3 に put する
- [x] release build の際は Buffett Code, Inc のコードサイニング証明書を作る
- [x] `master`, `v*` のtagの push 時に release build を行う