### PR TITLE
Create new bc api client module

### DIFF
--- a/BuffettCode.sln
+++ b/BuffettCode.sln
@@ -25,6 +25,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuffettCodeExcelFunctions",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuffettCodeExcelFunctionsTest", "BuffettCodeExcelFunctionsTest\BuffettCodeExcelFunctionsTest.csproj", "{DB6AC57E-12E1-4020-ABA0-AD76F4066BB9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuffettCodeAPIClient", "BuffettCodeAPIClient\BuffettCodeAPIClient.csproj", "{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A} = {8552CFD4-39C4-47D9-A0FA-BE33B952465A}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuffettCodeCommon", "BuffettCodeCommon\BuffettCodeCommon.csproj", "{8552CFD4-39C4-47D9-A0FA-BE33B952465A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuffettCodeAPIClientTests", "BuffettCodeAPIClientTests\BuffettCodeAPIClientTests.csproj", "{5826FE1B-2227-462B-9A3C-AF3434106028}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuffettCodeCommonTests", "BuffettCodeCommonTests\BuffettCodeCommonTests.csproj", "{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		AppVeyor|Any CPU = AppVeyor|Any CPU
@@ -127,6 +138,54 @@ Global
 		{DB6AC57E-12E1-4020-ABA0-AD76F4066BB9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DB6AC57E-12E1-4020-ABA0-AD76F4066BB9}.Release|x86.ActiveCfg = Release|Any CPU
 		{DB6AC57E-12E1-4020-ABA0-AD76F4066BB9}.Release|x86.Build.0 = Release|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.AppVeyor|Any CPU.ActiveCfg = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.AppVeyor|Any CPU.Build.0 = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.AppVeyor|x86.ActiveCfg = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.AppVeyor|x86.Build.0 = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Debug|x86.Build.0 = Debug|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Release|x86.ActiveCfg = Release|Any CPU
+		{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}.Release|x86.Build.0 = Release|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.AppVeyor|Any CPU.ActiveCfg = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.AppVeyor|Any CPU.Build.0 = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.AppVeyor|x86.ActiveCfg = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.AppVeyor|x86.Build.0 = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Debug|x86.Build.0 = Debug|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Release|x86.ActiveCfg = Release|Any CPU
+		{8552CFD4-39C4-47D9-A0FA-BE33B952465A}.Release|x86.Build.0 = Release|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.AppVeyor|Any CPU.ActiveCfg = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.AppVeyor|Any CPU.Build.0 = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.AppVeyor|x86.ActiveCfg = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.AppVeyor|x86.Build.0 = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Debug|x86.Build.0 = Debug|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Release|x86.ActiveCfg = Release|Any CPU
+		{5826FE1B-2227-462B-9A3C-AF3434106028}.Release|x86.Build.0 = Release|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.AppVeyor|Any CPU.ActiveCfg = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.AppVeyor|Any CPU.Build.0 = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.AppVeyor|x86.ActiveCfg = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.AppVeyor|x86.Build.0 = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Debug|x86.Build.0 = Debug|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Release|x86.ActiveCfg = Release|Any CPU
+		{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BuffettCodeAPIClient/ApiClientCore.cs
+++ b/BuffettCodeAPIClient/ApiClientCore.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace BuffettCodeAPIClient
+{
+    /// <summary>
+    /// BuffettCode API と Http でやり取りする Client のコアクラス
+    /// </summary>
+        
+    public class ApiClientCore
+    {
+        private readonly string apiKey;
+        private readonly Uri baseUri;
+        private static long TimeoutMilliseconds = 5000; 
+
+        private ApiClientCore(string apiKey, Uri baseUri)
+        {
+            this.apiKey = apiKey;
+            this.baseUri = baseUri;
+        }
+
+        public static ApiClientCore Create(string apiKey, string baseUrl)
+        {
+            return new ApiClientCore(apiKey, new Uri(baseUrl));
+        }
+
+        public static ApiClientCore Create(string apiKey, Uri baseUrl)
+        {
+            return new ApiClientCore(apiKey, baseUrl);
+        }
+
+         
+        private HttpClient NewHttpClient()
+        {
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = baseUri;
+            httpClient.Timeout = TimeSpan.FromMilliseconds(TimeoutMilliseconds);
+            httpClient.DefaultRequestHeaders.Accept.Clear();
+            httpClient.DefaultRequestHeaders.Accept.Add(
+                    new MediaTypeWithQualityHeaderValue("application/json"));
+            httpClient.DefaultRequestHeaders.Add("x-api-key", apiKey);
+            return httpClient;
+        }
+
+        public static string BuildGetPath(string endpoint, Dictionary<string, string> parameters)
+        {
+            return $"{endpoint}?{new FormUrlEncodedContent(parameters).ReadAsStringAsync().Result}";
+        }
+        
+        public async Task<string> Get(string endpoint, Dictionary<string, string> parameters, bool isConfigureAwait)
+        {
+            var path = BuildGetPath(endpoint, parameters);
+            using (var client = NewHttpClient())
+            {
+                var response = await client.GetAsync(path).ConfigureAwait(isConfigureAwait);
+                if (!response.IsSuccessStatusCode)
+                {
+                    switch ((int)response.StatusCode)
+                    {
+                        case (int)HttpStatusCode.Forbidden:
+                            throw new InvalidAPIKeyException();
+                        case 429: // Quota Error
+                            throw new QuotaException();
+                        default:
+                            throw new BuffettCodeApiClientException();
+                    }
+                }
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(isConfigureAwait);
+            }
+        }
+    }
+
+
+}

--- a/BuffettCodeAPIClient/BuffettCodeAPIClient.csproj
+++ b/BuffettCodeAPIClient/BuffettCodeAPIClient.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BuffettCodeAPIClient</RootNamespace>
+    <AssemblyName>BuffettCodeAPIClient</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Text.Json, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ApiClientCore.cs" />
+    <Compile Include="BuffettCodeApiClientException.cs" />
+    <Compile Include="BuffettCodeApiV3RequestCreator.cs" />
+    <Compile Include="BuffettCodeApiV3Client.cs" />
+    <Compile Include="BuffettCodeApiV2Client.cs" />
+    <Compile Include="BuffettCodeApiV2RequestCreator.cs" />
+    <Compile Include="Config\BuffettCodeApiConfig.cs" />
+    <Compile Include="IBuffettCodeApiClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BuffettCodeCommon\BuffettCodeCommon.csproj">
+      <Project>{8552cfd4-39c4-47d9-a0fa-be33b952465a}</Project>
+      <Name>BuffettCodeCommon</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BuffettCodeAPIClient/BuffettCodeApiClientException.cs
+++ b/BuffettCodeAPIClient/BuffettCodeApiClientException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+namespace BuffettCodeAPIClient
+{
+    /// <summary>
+    /// Default Exception on BuffettCode Api Client
+    /// </summary>
+    public class BuffettCodeApiClientException : Exception
+    {
+    }
+
+    public class  InvalidAPIKeyException : BuffettCodeApiClientException 
+    {
+    }   
+
+    public class QuotaException : BuffettCodeApiClientException
+    {
+    }
+
+    
+}

--- a/BuffettCodeAPIClient/BuffettCodeApiV2Client.cs
+++ b/BuffettCodeAPIClient/BuffettCodeApiV2Client.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BuffettCodeCommon.Validator;
+using BuffettCodeAPIClient.Config;
+
+
+
+namespace BuffettCodeAPIClient
+{
+    public class BuffettCodeApiV2Client : IBuffettCodeApiClient
+    {
+        private readonly ApiClientCore httpClient;
+        public BuffettCodeApiV2Client(string apiKey)
+        {
+            this.httpClient = ApiClientCore.Create(apiKey, BuffettCodeApiV2Config.BASE_URL);
+        }
+
+        public async Task<String> GetQuarter(string ticker, uint fiscalYear, uint fiscalQuarter, bool useOndemand, bool isConfigureAwait)
+        {
+            var (endpoint, paramaters) = BuffettCodeApiV2RequestCreator.CreateGetQuarterRequest(ticker, fiscalYear, fiscalQuarter, useOndemand);
+           return await httpClient.Get(endpoint, paramaters, isConfigureAwait);
+        }
+
+        public async Task<String> GetIndicator(string ticker, bool isConfigureAwait)
+        {
+            var (endpoint, paramaters) = BuffettCodeApiV2RequestCreator.CreateGetIndicatorRequest
+                (ticker);
+           return await httpClient.Get(endpoint, paramaters, isConfigureAwait);
+        }
+
+
+
+    }
+}

--- a/BuffettCodeAPIClient/BuffettCodeApiV2RequestCreator.cs
+++ b/BuffettCodeAPIClient/BuffettCodeApiV2RequestCreator.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using BuffettCodeCommon.Validator;
+using BuffettCodeAPIClient.Config;
+
+
+
+namespace BuffettCodeAPIClient
+{
+    public class BuffettCodeApiV2RequestCreator
+    {
+        public static (string, Dictionary<string, string>) CreateGetQuarterRequest(string ticker, uint fiscalYear, uint fiscalQuarter, bool useOndemand)
+        {
+            JpTickerValidator.Validate(ticker);
+            FiscalYearValidator.Validate(fiscalYear);
+            FiscalQuarterValidator.Validate(fiscalQuarter);
+            var paramaters = new Dictionary<string, string>()
+             {
+                 {"ticker", ticker },
+                 {"fy", fiscalYear.ToString() },
+                 {"fq", fiscalQuarter.ToString() },
+             };
+
+            var endpoint = useOndemand ?
+                BuffettCodeApiV2Config.ENDPOINT_ONDEMAND_QUARTER : BuffettCodeApiV2Config.ENDPOINT_QUARTER;
+
+            return (endpoint, paramaters);
+        }
+        public static (string, Dictionary<string, string>) CreateGetIndicatorRequest(string ticker)
+        {
+            JpTickerValidator.Validate(ticker);
+            var paramaters = new Dictionary<string, string>()
+             {
+                 {"tickers", ticker },
+             };
+
+            return (BuffettCodeApiV2Config.ENDPOINT_INDICATOR, paramaters);
+        }
+
+    }
+}

--- a/BuffettCodeAPIClient/BuffettCodeApiV3Client.cs
+++ b/BuffettCodeAPIClient/BuffettCodeApiV3Client.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BuffettCodeCommon.Validator;
+using BuffettCodeAPIClient.Config;
+
+
+namespace BuffettCodeAPIClient
+{
+    public class BuffettCodeApiV3Client : IBuffettCodeApiClient
+    {
+        private readonly ApiClientCore httpClient;
+
+        public BuffettCodeApiV3Client(string apiKey)
+        {
+            this.httpClient = ApiClientCore.Create(apiKey, BuffettCodeApiV3Config.BASE_URL);
+        }
+
+        public async Task<String> GetDaily(string ticker, DateTime day, bool useOndemand, bool isConfigureAwait)
+        {
+            var (endPoint, paramaters) = BuffettCodeApiV3RequestCreator.CreateGetDailyRequest(ticker, day, useOndemand);
+            JpTickerValidator.Validate(ticker);
+            return await httpClient.Get(endPoint, paramaters, isConfigureAwait);
+       }
+
+    }
+}

--- a/BuffettCodeAPIClient/BuffettCodeApiV3RequestCreator.cs
+++ b/BuffettCodeAPIClient/BuffettCodeApiV3RequestCreator.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using BuffettCodeCommon.Validator;
+using BuffettCodeAPIClient.Config;
+
+
+
+namespace BuffettCodeAPIClient
+{
+    public class BuffettCodeApiV3RequestCreator
+    {
+        public static (string, Dictionary<string, string>) CreateGetDailyRequest(string ticker, DateTime date, bool useOndemand)
+        {
+            JpTickerValidator.Validate(ticker);
+           var paramaters = new Dictionary<string, string>()
+             {
+                 {"ticker", ticker },
+                 {"date", date.Date.ToString("yyyy-MM-dd") },
+             };
+ 
+            var endpoint = useOndemand ?
+                BuffettCodeApiV3Config.ENDPOINT_ONDEMAND_DAILY : BuffettCodeApiV3Config.ENDPOINT_DAILY;
+
+            return (endpoint, paramaters);
+        }
+    }
+}

--- a/BuffettCodeAPIClient/Config/BuffettCodeApiConfig.cs
+++ b/BuffettCodeAPIClient/Config/BuffettCodeApiConfig.cs
@@ -1,0 +1,25 @@
+﻿namespace BuffettCodeAPIClient.Config
+{
+
+    public static class BuffettCodeApiConfig
+    {
+        public static readonly string VERSION_V2 = "v2";
+        public static readonly string VERSION_V3 = "v3";
+    }
+
+    public static class BuffettCodeApiV2Config
+    {
+        public static readonly string BASE_URL = "https://api.buffett-code.com/api/v2/";
+        public static readonly string ENDPOINT_QUARTER  = "quarter";
+        public static readonly string ENDPOINT_ONDEMAND_QUARTER  = "ondemand/quarter";
+        public static readonly string ENDPOINT_INDICATOR  = "indicator";
+        public static readonly string ENDPOINT_DAILY = "daily";
+    }
+
+    public static class BuffettCodeApiV3Config
+    {
+        public static readonly string BASE_URL = "https://api.buffett-code.com/api/v3/";
+        public static readonly string ENDPOINT_DAILY = "daily";
+        public static readonly string ENDPOINT_ONDEMAND_DAILY = "ondemand/daily";
+    }
+}

--- a/BuffettCodeAPIClient/IBuffettCodeApiClient.cs
+++ b/BuffettCodeAPIClient/IBuffettCodeApiClient.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuffettCodeAPIClient
+{
+    interface IBuffettCodeApiClient
+    {
+    }
+}

--- a/BuffettCodeAPIClient/Properties/AssemblyInfo.cs
+++ b/BuffettCodeAPIClient/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BuffettCodeAPIClient")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BuffettCodeAPIClient")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("79daca04-c2b5-4d1b-996d-2ea1ad79909f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BuffettCodeAPIClientTests/ApiClientCoreTests.cs
+++ b/BuffettCodeAPIClientTests/ApiClientCoreTests.cs
@@ -1,0 +1,36 @@
+﻿namespace BuffettCodeAPIClient.Tests
+{
+    using BuffettCodeAPIClient;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+
+    /// <summary>
+    /// Defines the <see cref="ApiClientCoreTests" />.
+    /// </summary>
+    [TestClass()]
+    public class ApiClientCoreTests
+    {
+        /// <summary>
+        /// The newHttpClientTest.
+        /// </summary>
+        [TestMethod()]
+        public void NewHttpClientTest()
+        {
+            var apiKey = "dummy_api_key";
+            var baseUrl = "https://example.com";
+            var clientCore = ApiClientCore.Create(apiKey, baseUrl);
+
+            // to test private method
+            var privateObj = new PrivateObject(clientCore).Invoke("NewHttpClient");
+
+            Assert.IsInstanceOfType(privateObj, typeof(HttpClient));
+            HttpClient httpClient = (HttpClient)privateObj;
+            var xApiKeyHeaders = new List<string>(httpClient.DefaultRequestHeaders.GetValues("x-api-key"));
+            Assert.AreEqual(new Uri(baseUrl), httpClient.BaseAddress);
+            Assert.AreEqual(1, xApiKeyHeaders.Count);
+            Assert.AreEqual(apiKey, xApiKeyHeaders[0]);
+        }
+    }
+}

--- a/BuffettCodeAPIClientTests/ApiTestConfig.cs
+++ b/BuffettCodeAPIClientTests/ApiTestConfig.cs
@@ -1,0 +1,14 @@
+﻿namespace BuffettCodeAPIClient.Tests
+{
+    /// <summary>
+    /// Defines the <see cref="ApiTestConfig" />.
+    /// </summary>
+    internal class ApiTestConfig
+    {
+        // ref: https://docs.buffett-code.com/
+        /// <summary>
+        /// Defines the TEST_API_KEY.
+        /// </summary>
+        public static readonly string TEST_API_KEY = "sAJGq9JH193KiwnF947v74KnDYkO7z634LWQQfPY";
+    }
+}

--- a/BuffettCodeAPIClientTests/BuffettCodeAPIClientTests.csproj
+++ b/BuffettCodeAPIClientTests/BuffettCodeAPIClientTests.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5826FE1B-2227-462B-9A3C-AF3434106028}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BuffettCodeAPIClient.Tests</RootNamespace>
+    <AssemblyName>BuffettCodeAPIClientTests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ApiClientCoreTests.cs" />
+    <Compile Include="BuffettCodeApiV2ClientTests.cs" />
+    <Compile Include="BuffettCodeApiV2RequestCreatorTests.cs" />
+    <Compile Include="BuffettCodeApiV3ClientTests.cs" />
+    <Compile Include="ApiTestConfig.cs" />
+    <Compile Include="BuffettCodeApiV3RequestCreatorTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BuffettCodeAPIClient\BuffettCodeAPIClient.csproj">
+      <Project>{79DACA04-C2B5-4D1B-996D-2EA1AD79909F}</Project>
+      <Name>BuffettCodeAPIClient</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\BuffettCodeCommon\BuffettCodeCommon.csproj">
+      <Project>{8552cfd4-39c4-47d9-a0fa-be33b952465a}</Project>
+      <Name>BuffettCodeCommon</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/BuffettCodeAPIClientTests/BuffettCodeApiV2ClientTests.cs
+++ b/BuffettCodeAPIClientTests/BuffettCodeApiV2ClientTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BuffettCodeAPIClient;
+
+namespace BuffettCodeAPIClient.Tests
+{
+    using BuffettCodeAPIClient;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Defines the <see cref="BuffettCodeApiV2ClientTests" />.
+    /// </summary>
+    [TestClass()]
+    public class BuffettCodeApiV2ClientTests
+    {
+        /// <summary>
+        /// Defines the client.
+        /// </summary>
+        private BuffettCodeApiV2Client client = new BuffettCodeApiV2Client(ApiTestConfig.TEST_API_KEY);
+
+        /// <summary>
+        /// The GetQuarterTest.
+        /// </summary>
+        [TestMethod()]
+        public void GetQuarterTest()
+        {
+            uint fy = 2019;
+            uint fq = 4;
+
+            // test api key can get ticker=xx01
+            Assert.IsNotNull(client.GetQuarter("6501", fy, fq, false, true).Result);
+
+            // test api key can get ticker=xx02
+            Assert.ThrowsExceptionAsync<InvalidAPIKeyException>(() => client.GetQuarter("6502", fy, fq, false, true));
+        }
+
+        [TestMethod()]
+        public void GetIndicatorTest()
+        {
+            // test api key can get ticker=xx01
+            Assert.IsNotNull(client.GetIndicator("6501", true).Result);
+
+            // test api key can get ticker=xx02
+            Assert.ThrowsExceptionAsync<InvalidAPIKeyException>(() => client.GetIndicator("6502", true));
+        }
+    }
+}

--- a/BuffettCodeAPIClientTests/BuffettCodeApiV2RequestCreatorTests.cs
+++ b/BuffettCodeAPIClientTests/BuffettCodeApiV2RequestCreatorTests.cs
@@ -1,0 +1,65 @@
+﻿using BuffettCodeAPIClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BuffettCodeAPIClient.Config;
+using BuffettCodeCommon.Validator;
+
+
+namespace BuffettCodeAPIClient.Tests
+{
+    [TestClass()]
+    public class BuffettCodeApiV2RequestCreatorTests
+    {
+        [TestMethod()]
+        public void CreateGetQuarterRequestTest()
+        {
+            // ok case
+            var ticker = "6591";
+            uint fiscalYear = 2019;
+            uint fiscalQuarter = 3;
+
+            // use ondemand
+            var (endpoint, param) = BuffettCodeApiV2RequestCreator.CreateGetQuarterRequest(ticker, fiscalYear, fiscalQuarter, true);
+            Assert.AreEqual(endpoint, BuffettCodeApiV2Config.ENDPOINT_ONDEMAND_QUARTER);
+            Assert.AreEqual(ticker, param["ticker"]);
+            Assert.AreEqual(fiscalYear.ToString(), param["fy"]);
+            Assert.AreEqual(fiscalQuarter.ToString(), param["fq"]);
+
+
+            // not use ondemand
+            (endpoint, param) = BuffettCodeApiV2RequestCreator.CreateGetQuarterRequest(ticker, fiscalYear, fiscalQuarter, false);
+            Assert.AreEqual(endpoint, BuffettCodeApiV2Config.ENDPOINT_QUARTER);
+            Assert.AreEqual(ticker, param["ticker"]);
+            Assert.AreEqual(fiscalYear.ToString(), param["fy"]);
+            Assert.AreEqual(fiscalQuarter.ToString(), param["fq"]);
+
+
+            // validation Errors
+            Assert.ThrowsException<ValidationError>(
+                () =>
+                BuffettCodeApiV2RequestCreator.CreateGetQuarterRequest("aaa", fiscalYear, fiscalQuarter, false)
+                );
+            Assert.ThrowsException<ValidationError>(
+                () =>
+                BuffettCodeApiV2RequestCreator.CreateGetQuarterRequest(ticker, 1, fiscalQuarter, false)
+                );
+            Assert.ThrowsException<ValidationError>(
+                () =>
+                BuffettCodeApiV2RequestCreator.CreateGetQuarterRequest(ticker, fiscalYear, 10, false)
+                );
+
+        }
+
+        [TestMethod()]
+        public void CreateGetIndicatorRequestTest()
+        {
+            // ok case
+            var ticker = "6501";
+            var (endpoint, param) = BuffettCodeApiV2RequestCreator.CreateGetIndicatorRequest(ticker);
+            Assert.AreEqual(endpoint, BuffettCodeApiV2Config.ENDPOINT_INDICATOR);
+            Assert.AreEqual(ticker, param["tickers"]);
+
+            // validation errors
+            Assert.ThrowsException<ValidationError>(() => BuffettCodeApiV2RequestCreator.CreateGetIndicatorRequest("aaa"));
+        }
+    }
+}

--- a/BuffettCodeAPIClientTests/BuffettCodeApiV3ClientTests.cs
+++ b/BuffettCodeAPIClientTests/BuffettCodeApiV3ClientTests.cs
@@ -1,0 +1,33 @@
+﻿namespace BuffettCodeAPIClient.Tests
+{
+    using BuffettCodeAPIClient;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+
+    /// <summary>
+    /// Defines the <see cref="BuffettCodeApiV3ClientTests" />.
+    /// </summary>
+    [TestClass()]
+    public class BuffettCodeApiV3ClientTests
+    {
+        /// <summary>
+        /// Defines the client.
+        /// </summary>
+        private BuffettCodeApiV3Client client = new BuffettCodeApiV3Client(ApiTestConfig.TEST_API_KEY);
+
+        /// <summary>
+        /// The GetDailyTest.
+        /// </summary>
+        [TestMethod()]
+        public void GetDailyTest()
+        {
+            // test api key can get ticker=xx01 data
+            var day = new DateTime(2021, 2, 1);
+            Assert.IsNotNull(client.GetDaily("6501", day, false, true).Result);
+
+            // test api key can get ticker=xx02
+            Assert.ThrowsExceptionAsync<InvalidAPIKeyException>
+                (() => client.GetDaily("6502", day, true, true));
+        }
+    }
+}

--- a/BuffettCodeAPIClientTests/BuffettCodeApiV3RequestCreatorTests.cs
+++ b/BuffettCodeAPIClientTests/BuffettCodeApiV3RequestCreatorTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BuffettCodeAPIClient;
+using BuffettCodeAPIClient.Config;
+using BuffettCodeCommon.Validator;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuffettCodeAPIClient.Tests
+{
+    [TestClass()]
+    public class BuffettCodeApiV3RequestCreatorTests
+    {
+        [TestMethod()]
+        public void CreateGetDailyRequestTest()
+        {
+            // use ondemand
+            var ticker = "6501";
+            var day = new DateTime(2021, 1, 1);
+            var (endpoint, paramater) = BuffettCodeApiV3RequestCreator.CreateGetDailyRequest(ticker, day, true);
+            Assert.AreEqual(BuffettCodeApiV3Config.ENDPOINT_ONDEMAND_DAILY, endpoint); 
+            Assert.AreEqual(ticker, paramater["ticker"]); 
+            Assert.AreEqual("2021-01-01", paramater["date"]); 
+
+            // not use ondemand
+            (endpoint, paramater) = BuffettCodeApiV3RequestCreator.CreateGetDailyRequest(ticker, day, false);
+            Assert.AreEqual(BuffettCodeApiV3Config.ENDPOINT_DAILY, endpoint); 
+            Assert.AreEqual(ticker, paramater["ticker"]); 
+            Assert.AreEqual("2021-01-01", paramater["date"]);
+
+            // validation error
+            Assert.ThrowsException<ValidationError>(() => BuffettCodeApiV3RequestCreator.CreateGetDailyRequest("aa", day, false));
+        }
+    }
+}

--- a/BuffettCodeAPIClientTests/Properties/AssemblyInfo.cs
+++ b/BuffettCodeAPIClientTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BuffettCodeAPIClientTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BuffettCodeAPIClientTests")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5826fe1b-2227-462b-9a3c-af3434106028")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BuffettCodeAPIClientTests/packages.config
+++ b/BuffettCodeAPIClientTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net472" />
+</packages>

--- a/BuffettCodeCommon/BuffettCodeCommon.csproj
+++ b/BuffettCodeCommon/BuffettCodeCommon.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8552CFD4-39C4-47D9-A0FA-BE33B952465A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BuffettCodeCommon</RootNamespace>
+    <AssemblyName>BuffettCodeCommon</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Validator\FiscalQuarterValidator.cs" />
+    <Compile Include="Validator\FiscalYearValidator.cs" />
+    <Compile Include="Validator\ValidationError.cs" />
+    <Compile Include="Validator\TickerValidator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BuffettCodeCommon/Properties/AssemblyInfo.cs
+++ b/BuffettCodeCommon/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BuffettCodeCommon")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BuffettCodeCommon")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8552cfd4-39c4-47d9-a0fa-be33b952465a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BuffettCodeCommon/Validator/FiscalQuarterValidator.cs
+++ b/BuffettCodeCommon/Validator/FiscalQuarterValidator.cs
@@ -1,0 +1,27 @@
+﻿namespace BuffettCodeCommon.Validator
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Defines the <see cref="FiscalQuarterValidator" />.
+    /// </summary>
+    public class FiscalQuarterValidator
+    {
+        /// <summary>
+        /// Defines the QUARTERS.
+        /// </summary>
+        private static readonly HashSet<uint> QUARTERS = new HashSet<uint> { 1, 2, 3, 4, 5 };
+
+        /// <summary>
+        /// The Validate.
+        /// </summary>
+        /// <param name="maybeFiscalQuarter">The quarter<see cref="uint"/>.</param>
+        public static void Validate(uint maybeFiscalQuarter)
+        {
+            if (!QUARTERS.Contains(maybeFiscalQuarter))
+            {
+                throw new ValidationError($"{maybeFiscalQuarter} is not in {QUARTERS}");
+            }
+        }
+    }
+}

--- a/BuffettCodeCommon/Validator/FiscalYearValidator.cs
+++ b/BuffettCodeCommon/Validator/FiscalYearValidator.cs
@@ -1,0 +1,24 @@
+﻿namespace BuffettCodeCommon.Validator
+{
+    /// <summary>
+    /// Defines the <see cref="FiscalYearValidator" />.
+    /// </summary>
+    public class FiscalYearValidator
+    {
+        /// <summary>
+        /// The Validate.
+        /// </summary>
+        /// <param name="maybeFiscalYear">The fiscalYear<see cref="uint"/>.</param>
+        public static void Validate(uint maybeFiscalYear)
+        {
+            if (maybeFiscalYear < 1900)
+            {
+                throw new ValidationError($"fiscalYear={maybeFiscalYear} is too small.");
+            }
+            else if (maybeFiscalYear > 2100)
+            {
+                throw new ValidationError($"fiscalYear={maybeFiscalYear} is too large.");
+            }
+        }
+    }
+}

--- a/BuffettCodeCommon/Validator/TickerValidator.cs
+++ b/BuffettCodeCommon/Validator/TickerValidator.cs
@@ -1,0 +1,28 @@
+﻿namespace BuffettCodeCommon.Validator
+{
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Defines the <see cref="JpTickerValidator" />.
+    /// </summary>
+    public static class JpTickerValidator
+    {
+        // jp ticker: 1000 - 9999
+        /// <summary>
+        /// Defines the TICKER_PATTTERN.
+        /// </summary>
+        private readonly static Regex TICKER_PATTTERN = new Regex("^[1-9][0-9]{3}$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// The Validate.
+        /// </summary>
+        /// <param name="maybeTicker">The maybeTicker<see cref="string"/>.</param>
+        public static void Validate(string maybeTicker)
+        {
+            if (!TICKER_PATTTERN.IsMatch(maybeTicker))
+            {
+                throw new ValidationError($"ticker must be '1000' - '9999', but {maybeTicker} is given");
+            }
+        }
+    }
+}

--- a/BuffettCodeCommon/Validator/ValidationError.cs
+++ b/BuffettCodeCommon/Validator/ValidationError.cs
@@ -1,0 +1,36 @@
+﻿namespace BuffettCodeCommon.Validator
+{
+    using System;
+
+    /// <summary>
+    /// Exception class for Validation Error.
+    /// </summary>
+    public class ValidationError : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationError"/> class.
+        /// </summary>
+        public ValidationError()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationError"/> class.
+        /// </summary>
+        /// <param name="message">The message<see cref="string"/>.</param>
+        public ValidationError(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationError"/> class.
+        /// </summary>
+        /// <param name="message">The message<see cref="string"/>.</param>
+        /// <param name="inner">The inner<see cref="Exception"/>.</param>
+        public ValidationError(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/BuffettCodeCommonTests/BuffettCodeCommonTests.csproj
+++ b/BuffettCodeCommonTests/BuffettCodeCommonTests.csproj
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E55D4F71-9AA4-435E-898A-7ADB72FBBA95}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BuffettCodeCommonTests</RootNamespace>
+    <AssemblyName>BuffettCodeCommonTests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Validator\FiscalQuarterValidatorTests.cs" />
+    <Compile Include="Validator\FiscalYearValidatorTests.cs" />
+    <Compile Include="Validator\JpTickerValidatorTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BuffettCodeCommon\BuffettCodeCommon.csproj">
+      <Project>{8552CFD4-39C4-47D9-A0FA-BE33B952465A}</Project>
+      <Name>BuffettCodeCommon</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/BuffettCodeCommonTests/Properties/AssemblyInfo.cs
+++ b/BuffettCodeCommonTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BuffettCodeCommonTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BuffettCodeCommonTests")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e55d4f71-9aa4-435e-898a-7adb72fbba95")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BuffettCodeCommonTests/Validator/FiscalQuarterValidatorTests.cs
+++ b/BuffettCodeCommonTests/Validator/FiscalQuarterValidatorTests.cs
@@ -1,0 +1,29 @@
+﻿namespace BuffettCodeCommon.Validator.Tests
+{
+    using BuffettCodeCommon.Validator;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Defines the <see cref="FiscalQuarterValidatorTests" />.
+    /// </summary>
+    [TestClass()]
+    public class FiscalQuarterValidatorTests
+    {
+        /// <summary>
+        /// The ValidateTest.
+        /// </summary>
+        [TestMethod()]
+        public void ValidateTest()
+        {
+            // 1 - 5  is quarter, path validate method
+            new List<uint> { 1, 2, 3, 4, 5 }.ForEach(q => FiscalQuarterValidator.Validate(q));
+
+            // error case, 0 or 6+ int
+            Assert.ThrowsException<ValidationError>(() => FiscalQuarterValidator.Validate(0));
+
+
+            Assert.ThrowsException<ValidationError>(() => FiscalQuarterValidator.Validate(6));
+        }
+    }
+}

--- a/BuffettCodeCommonTests/Validator/FiscalYearValidatorTests.cs
+++ b/BuffettCodeCommonTests/Validator/FiscalYearValidatorTests.cs
@@ -1,0 +1,28 @@
+﻿namespace BuffettCodeCommon.Validator.Tests
+{
+    using BuffettCodeCommon.Validator;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Defines the <see cref="FiscalYearValidatorTests" />.
+    /// </summary>
+    [TestClass()]
+    public class FiscalYearValidatorTests
+    {
+        /// <summary>
+        /// The ValidateTest.
+        /// </summary>
+        [TestMethod()]
+        public void ValidateTest()
+        {
+            // ok case
+            new List<uint> { 1901, 2000, 2020, 2099 }.ForEach(q => FiscalYearValidator.Validate(q));
+
+            // error case
+            Assert.ThrowsException<ValidationError>(() => FiscalYearValidator.Validate(0));
+            Assert.ThrowsException<ValidationError>(() => FiscalYearValidator.Validate(1899));
+            Assert.ThrowsException<ValidationError>(() => FiscalYearValidator.Validate(2101));
+        }
+    }
+}

--- a/BuffettCodeCommonTests/Validator/JpTickerValidatorTests.cs
+++ b/BuffettCodeCommonTests/Validator/JpTickerValidatorTests.cs
@@ -1,0 +1,29 @@
+﻿namespace BuffettCodeCommon.Validator.Tests
+{
+    using BuffettCodeCommon.Validator;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Defines the <see cref="JpTickerValidatorTests" />.
+    /// </summary>
+    [TestClass()]
+    public class JpTickerValidatorTests
+    {
+        /// <summary>
+        /// The TestJpTickerValidator.
+        /// </summary>
+        [TestMethod]
+        public void TestJpTickerValidator()
+        {
+            var tickers = new List<String> { "1000", "2000", "9999" };
+            tickers.ForEach(ticker => JpTickerValidator.Validate(ticker));
+
+            var nonTickers = new List<String> { "999", "10000", "aaa" };
+            nonTickers.ForEach(
+                noTicker =>
+                Assert.ThrowsException<ValidationError>(() => JpTickerValidator.Validate(noTicker)));
+        }
+    }
+}

--- a/BuffettCodeCommonTests/packages.config
+++ b/BuffettCodeCommonTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net472" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ GitHub extension for Visual Studio
 [https://github.com/BuffettCode/buffett-code-api-client-excel.git](https://github.com/BuffettCode/buffett-code-api-client-excel.git)
 
 #### デジタル署名の登録
+
 バフェットコードのExcelアドインの一部（`BuffettCodeAddinRibbon`）はVSTO(Visual Studio Tools for Office)を利用しており、ClickOnceのマニフェストにデジタル署名が必要です。`BuffettCode` プロジェクトにデジタル署名の設定がされている必要があります。リポジトリにコミットされたテスト証明書([BuffettCodeTest.pfx](./BuffettCodeAddinRibbon/BuffettCodeTest.pfx))を使う場合は以下のように設定します。
 
 

--- a/scripts/install_dependencies.ps1
+++ b/scripts/install_dependencies.ps1
@@ -1,4 +1,18 @@
-$Packages = ("BuffettCodeAddinRibbon", "BuffettCodeAddinRibbonTest", "BuffettCodeIO", "BuffettCodeIOTest", "BuffettCodeInstaller", "InstallerCA", "BuffettCodeExcelFunctions", "BuffettCodeExcelFunctionsTest")
+$Packages = (
+    "BuffettCodeAddinRibbon",
+    "BuffettCodeAddinRibbonTest",
+    "BuffettCodeIO",
+    "BuffettCodeIOTest",
+    "BuffettCodeInstaller",
+    "InstallerCA",
+    "BuffettCodeExcelFunctions",
+    "BuffettCodeExcelFunctionsTest",
+    "BuffettCodeAPIClient",
+    "BuffettCodeAPIClientTests",
+    "BuffettCodeCommon",
+    "BuffettCodeCommonTests"
+    )
+
 foreach($Pkg in $Packages) {
     echo "install package in $Pkg"
     nuget install $Pkg\packages.config -OutputDirectory packages

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -1,2 +1,7 @@
 $Env:BCApiKey= "sAJGq9JH193KiwnF947v74KnDYkO7z634LWQQfPY"
-VSTest.Console.exe .\BuffettCodeAddinRibbonTest\bin\Release\BuffettCodeAddinRibbonTest.dll .\BuffettCodeIOTest\bin\Release\BuffettCodeIOTest.dll .\BuffettCodeExcelFunctionsTest\bin\Release\BuffettCodeExcelFunctionsTest.dll
+VSTest.Console.exe `
+ .\BuffettCodeAddinRibbonTest\bin\Release\BuffettCodeAddinRibbonTest.dll `
+ .\BuffettCodeIOTest\bin\Release\BuffettCodeIOTest.dll `
+ .\BuffettCodeExcelFunctionsTest\bin\Release\BuffettCodeExcelFunctionsTest.dll `
+ .\BuffettCodeAPIClientTests\bin\Release\BuffettCodeAPIClientTests.dll `
+ .\BuffettCodeCommonTests\bin\Release\BuffettCodeCommonTests.dll `


### PR DESCRIPTION
BuffettCodeAPI V2, V3 用に新しいAPI client を実装しました。
`BuffettCodeIO` では古い実装を使っているので、エクセルアドオン本体で参照している箇所はまだありません