### PR TITLE
Add api error handling

### DIFF
--- a/BuffettCodeExcelFunctions/UserDefinedFunctions.cs
+++ b/BuffettCodeExcelFunctions/UserDefinedFunctions.cs
@@ -142,6 +142,10 @@ namespace BuffettCodeExcelFunctions
             {
                 message = $"取得可能な範囲を超えています::{bce.Message}";
             }
+            else if (bce is BuffettCodeApiClientException)
+            {
+                message = "APIの呼び出しでエラーが発生しました";
+            }
             else
             {
                 message = $"未定義のエラー::{bce.Message}";


### PR DESCRIPTION
API側でエラーが発生したとき(500など)のハンドリングがされておらずそのまま例外型が表示されてしまっていたため、メッセージを表示するハンドリングを追加しました。

![Screenshot (5)](https://user-images.githubusercontent.com/1457682/139632239-3766719f-c14a-4c88-8add-e6432043e0d3.png)
