### PR TITLE
Skip ondemand check for indicator call

### DIFF
--- a/BuffettCodeIO/ApiTaskHelper.cs
+++ b/BuffettCodeIO/ApiTaskHelper.cs
@@ -38,8 +38,16 @@ namespace BuffettCodeIO
         }
 
         public bool ShouldUseOndemandEndpoint(DataTypeConfig dataType, string ticker, IPeriod period, bool IsOndemandEndpointEnabled)
-       =>
-            FindAvailableTier(dataType, ticker, period, IsOndemandEndpointEnabled).Equals(SupportedTier.OndemandTier);
+        {
+            if (dataType == DataTypeConfig.Indicator)
+            {
+                return false;
+            }
+            else
+            {
+                return FindAvailableTier(dataType, ticker, period, IsOndemandEndpointEnabled).Equals(SupportedTier.OndemandTier);
+            }
+        }
 
         public IComparablePeriod FindEndOfOndemandPeriod(DataTypeConfig dataType, string ticker, PeriodRange<IComparablePeriod> periodRange, bool IsOndemandEndpointEnabled)
         {

--- a/BuffettCodeIOTests/ApiTaskHelperTests.cs
+++ b/BuffettCodeIOTests/ApiTaskHelperTests.cs
@@ -76,6 +76,10 @@ namespace BuffettCodeIO.Tests
             Assert.ThrowsException<NotSupportedTierException>(() => helper.ShouldUseOndemandEndpoint(DataTypeConfig.Quarter, ticker, ondemandOldest.Next() as FiscalQuarterPeriod, false));
             Assert.ThrowsException<NotSupportedTierException>(() => helper.ShouldUseOndemandEndpoint(DataTypeConfig.Quarter, ticker, ondemandLatest, false));
             Assert.ThrowsException<NotSupportedTierException>(() => helper.ShouldUseOndemandEndpoint(DataTypeConfig.Quarter, ticker, ondemandLatest.Next() as FiscalQuarterPeriod, false));
+
+            // indicator endpoint
+            Assert.IsFalse(helper.ShouldUseOndemandEndpoint(DataTypeConfig.Indicator, ticker, null, false));
+            Assert.IsFalse(helper.ShouldUseOndemandEndpoint(DataTypeConfig.Indicator, ticker, null, true));
         }
 
         [TestMethod()]


### PR DESCRIPTION
indicatorのAPIが呼び出せないバグを修正しました。

ondemandを利用するかのどうかのチェックで、indicatorの場合は常にfalseを返すようにします。

![Screenshot (6)](https://user-images.githubusercontent.com/1457682/139635293-3abd0a1b-6dac-43dc-945b-826ced6a2dec.png)
