### PR TITLE
Change endpoint selection logic

### DIFF
--- a/BuffettCodeExcelFunctions/ApiResourceFetcher.cs
+++ b/BuffettCodeExcelFunctions/ApiResourceFetcher.cs
@@ -14,10 +14,16 @@ namespace BuffettCodeExcelFunctions
         private static readonly BuffettCodeApiTaskProcessor processor = new BuffettCodeApiTaskProcessor(config.ApiVersion, config.ApiKey, config.MaxDegreeOfParallelism, config.IsOndemandEndpointEnabled
             );
 
+        private static bool IsQuarterCall(string parameter1, string parameter2)
+        {
+            return !string.IsNullOrWhiteSpace(parameter1) && !string.IsNullOrWhiteSpace(parameter2);
+        }
+
         public static IApiResource FetchForLegacy
             (string ticker, string parameter1, string parameter2, string propertyName)
         {
-            var dataType = resolver.Resolve(propertyName);
+            var dataType = IsQuarterCall(parameter1, parameter2) ? DataTypeConfig.Quarter : DataTypeConfig.Indicator;
+
             // update processor at first
             switch (dataType)
             {


### PR DESCRIPTION
BCODE関数がコールするエンドポイントを選択するロジックを、プロパティ名ベースから、FYFQパラメータベースに変更しました。

`debt` のようなindicatorでもquarterでも利用できる科目を取得する場合、以前のロジックでは内部でのマッピングの処理順に依存 (indicatorが優先) となっていました。
今回の修正により、FYFQが指定されていたらquarter、未指定ならindicatorを呼び出すようになり、spreadsheetアドオンと同じ挙動となります。

スクリーンショットのA1は6501のindicatorの値、A2は6501のquarterの値です。

![Screenshot (7)](https://user-images.githubusercontent.com/1457682/139650131-13bfba8e-b9e2-4aca-a9e6-02e487c4221b.png)


