### PR TITLE
キャッシュ戦略を改善

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,4 +45,4 @@ jobs:
         run: dotnet tool install -g dotnet-format --version 5.1.* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
       
       - name: Lint
-        run: dotnet format --check -v d
+        run: dotnet-format --check -v d

--- a/BuffettCodeAPIClient/ApiClientCoreWithCache.cs
+++ b/BuffettCodeAPIClient/ApiClientCoreWithCache.cs
@@ -1,3 +1,4 @@
+using BuffettCodeCommon;
 using System;
 using System.Runtime.Caching;
 
@@ -34,15 +35,19 @@ namespace BuffettCodeAPIClient
 
         public string Get(ApiGetRequest request, bool isConfigureAwait, bool useCache)
         {
-            if (useCache && cacheHelper.HasCache(request))
+            lock (ApiRequestLock.GetLockObject(request))
             {
-                return (string)cacheHelper.Get(request);
-            }
-            else
-            {
-                return apiClientCore.Get(request, isConfigureAwait).Result;
+                if (useCache && cacheHelper.HasCache(request))
+                {
+                    return (string)cacheHelper.Get(request);
+                }
+                else
+                {
+                    string result = apiClientCore.Get(request, isConfigureAwait).Result;
+                    cacheHelper.Set(request, result);
+                    return result;
+                }
             }
         }
-
     }
 }

--- a/BuffettCodeAPIClient/ApiRequestLock.cs
+++ b/BuffettCodeAPIClient/ApiRequestLock.cs
@@ -1,0 +1,33 @@
+using BuffettCodeCommon;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuffettCodeAPIClient
+{
+    public class ApiRequestLock
+    {
+        private static readonly Dictionary<string, object> lockObjects = new Dictionary<string, object>();
+
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public static object GetLockObject(ApiGetRequest request)
+        {
+            string lockKey = request.EndPoint;
+            if (request.Parameters.ContainsKey("ticker"))
+            {
+                lockKey += "_ticker=" + request.Parameters["ticker"];
+            }
+
+            if (!lockObjects.ContainsKey(lockKey))
+            {
+                lockObjects[lockKey] = new object();
+            }
+
+            return lockObjects[lockKey];
+        }
+    }
+}

--- a/BuffettCodeAPIClient/ApiRequestLock.cs
+++ b/BuffettCodeAPIClient/ApiRequestLock.cs
@@ -17,10 +17,7 @@ namespace BuffettCodeAPIClient
         public static object GetLockObject(ApiGetRequest request)
         {
             string lockKey = request.EndPoint;
-            if (request.Parameters.ContainsKey("ticker"))
-            {
-                lockKey += "_ticker=" + request.Parameters["ticker"];
-            }
+            lockKey += String.Join("&", request.Parameters.Select(kv => $"{kv.Key}={kv.Value}").OrderBy(str => str));
 
             if (!lockObjects.ContainsKey(lockKey))
             {

--- a/BuffettCodeAPIClient/BuffettCodeAPIClient.csproj
+++ b/BuffettCodeAPIClient/BuffettCodeAPIClient.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="ApiClientCore.cs" />
     <Compile Include="ApiClientFactory.cs" />
+    <Compile Include="ApiRequestLock.cs" />
     <Compile Include="BuffettCodeApiV3RequestCreator.cs" />
     <Compile Include="BuffettCodeApiV3Client.cs" />
     <Compile Include="ApiGetResponseBodyParser.cs" />

--- a/BuffettCodeAPIClientTests/ApiRequestLockTests.cs
+++ b/BuffettCodeAPIClientTests/ApiRequestLockTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace BuffettCodeAPIClient.Tests
+{
+    [TestClass]
+    public class ApiRequestLockTests
+    {
+        [TestMethod]
+        public void GetLockObjectTest()
+        {
+            var emptyParam = new Dictionary<string, string>();
+            var ticker1Param = new Dictionary<string, string>();
+            ticker1Param["ticker"] = "ticker1";
+            var ticker2Param = new Dictionary<string, string>();
+            ticker2Param["ticker"] = "ticker2";
+
+            var endpointAtickerEmptyReq = new ApiGetRequest("A", emptyParam);
+            var endpointAticker1Req = new ApiGetRequest("A", ticker1Param);
+            var endpointAticker2Req = new ApiGetRequest("A", ticker2Param);
+
+            var endpointBtickerEmptyReq = new ApiGetRequest("B", emptyParam);
+            var endpointBticker1Req = new ApiGetRequest("B", ticker1Param);
+            var endpointBticker2Req = new ApiGetRequest("B", ticker2Param);
+
+            Assert.AreEqual(ApiRequestLock.GetLockObject(endpointAtickerEmptyReq), ApiRequestLock.GetLockObject(endpointAtickerEmptyReq));
+            Assert.AreEqual(ApiRequestLock.GetLockObject(endpointAticker1Req), ApiRequestLock.GetLockObject(endpointAticker1Req));
+            Assert.AreEqual(ApiRequestLock.GetLockObject(endpointAticker2Req), ApiRequestLock.GetLockObject(endpointAticker2Req));
+
+            Assert.AreNotEqual(ApiRequestLock.GetLockObject(endpointAtickerEmptyReq), ApiRequestLock.GetLockObject(endpointAticker1Req));
+            Assert.AreNotEqual(ApiRequestLock.GetLockObject(endpointAtickerEmptyReq), ApiRequestLock.GetLockObject(endpointAticker2Req));
+            Assert.AreNotEqual(ApiRequestLock.GetLockObject(endpointAticker1Req), ApiRequestLock.GetLockObject(endpointAticker2Req));
+
+            Assert.AreNotEqual(ApiRequestLock.GetLockObject(endpointAtickerEmptyReq), ApiRequestLock.GetLockObject(endpointBtickerEmptyReq));
+            Assert.AreNotEqual(ApiRequestLock.GetLockObject(endpointAtickerEmptyReq), ApiRequestLock.GetLockObject(endpointBticker1Req));
+            Assert.AreNotEqual(ApiRequestLock.GetLockObject(endpointAticker1Req), ApiRequestLock.GetLockObject(endpointBticker2Req));
+
+        }
+    }
+}

--- a/BuffettCodeAPIClientTests/BuffettCodeAPIClientTests.csproj
+++ b/BuffettCodeAPIClientTests/BuffettCodeAPIClientTests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="ApiClientTestHelper.cs" />
     <Compile Include="ApiGetResponseReaderTests.cs" />
     <Compile Include="ApiGetResponseValidatorTests.cs" />
+    <Compile Include="ApiRequestLockTests.cs" />
     <Compile Include="BuffettCodeApiV3ClientTests.cs" />
     <Compile Include="BuffettCodeApiV3RequestCreatorTests.cs" />
     <Compile Include="ApiRequestCacheHelperTests.cs" />


### PR DESCRIPTION
キャッシュ戦略を改善しました。

`request` 単位でロックオブジェクトを生成& `lock` するようにした。
これをすることで、同じエンドポイントと同じtickerの API コールが複数同時に発生したときも、API コールは先頭の一回だけで二回目以降はキャッシュが使われるようになる。