### PR TITLE
CSVダウンロードを高速化

### DIFF
--- a/BuffettCodeIO/TabularOutput/WorksheetTabularWriter.cs
+++ b/BuffettCodeIO/TabularOutput/WorksheetTabularWriter.cs
@@ -22,11 +22,15 @@ namespace BuffettCodeIO.TabularOutput
         public void Write(Tabular<T> tabular)
         {
             uint rowIndex = 1;
+            worksheet.Application.ScreenUpdating = false;
+            worksheet.Application.Calculation = XlCalculation.xlCalculationManual;
             tabular.ToRows().ToList().ForEach(r =>
             {
                 WriteRow(rowIndex, r);
                 rowIndex++;
             });
+            worksheet.Application.Calculation = XlCalculation.xlCalculationAutomatic;
+            worksheet.Application.ScreenUpdating = true;
         }
 
         private void WriteRow(uint rowNumber, TabularRow row)


### PR DESCRIPTION
CSVダウンロードをしてエクセルシートに書き出す機能を高速化しました。
遅い原因は、大量のセルに書き込む際にエクセルの自動計算&更新が有効になっていたためで、
1セル書き込むたびにバックグラウンドで更新処理が走っていたから、が理由です。
これを改善するため、CSVデータを書き込んでいる途中では自動計算処理を一時的にオフにします。